### PR TITLE
Fixed a bug from poor implementation. Do it better next time.

### DIFF
--- a/Assets/IMPORT ME/UI/Scripts/Clover UI/Effects.meta
+++ b/Assets/IMPORT ME/UI/Scripts/Clover UI/Effects.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 00442a7f502e048edb7f2ed780405524
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/_External Assets/Clover Scripts/Events/InteractibleEvent.cs
+++ b/Assets/_External Assets/Clover Scripts/Events/InteractibleEvent.cs
@@ -63,7 +63,7 @@ public class InteractibleEvent : CommonBase {
 
 		//print ("scan");
 
-		foreach (Collider checker in (Physics.OverlapSphere (transform.position + offset, radius))) {
+		foreach (Collider checker in Physics.OverlapSphere (transform.position + offset, radius)) {
 			if (logDebugInfo)
 				print (checker);
 			//if (checker.gameObject.tag == "Player") {

--- a/Assets/_Visual Assets/Prefabs/Player Set.prefab
+++ b/Assets/_Visual Assets/Prefabs/Player Set.prefab
@@ -55,7 +55,7 @@ CapsuleCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 83879780991356310}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   m_Radius: 0.1
   m_Height: 1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Project 404
+
+Forked in case I ever develop motivation and to save the game should it be deleted
+
 Project 404 was a fangame being developed by a team of fans of Pikmin.
 I have left the project to move onto other projects, and a lack of motivation.
 If anyone can fork and continue the work that'd be great.


### PR DESCRIPTION
It was a single button press. An ex-dev took the time to fix bugs from poor implementation because people were complaining about it. I'm disappointed. Seriously. This implementation makes no sense, why do we need an entire object with colliders when we can just use the player's? This bug took me 10 minutes to find the cause of because I had to look through multiple scripts to figure out that it wasn't even caused by a script, and rather a collider. Then I had to look through more of the scripts to understand why we needed a second collider, and why the player's wasn't used. Turns out there wasn't really a good reason. I decided to TEST whether making the collider a trigger would work, and sure enough, it did, and it took me 2 seconds to implement the fix. Granted this is a coverup fix, and doesn't fix the root problem, but I can't be bothered to reimplement this entire system.